### PR TITLE
Fixed syntax error in use of env vars

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ COMMIT_SHA }}
+          ref: $COMMIT_SHA
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ COMMIT_SHA }}
+          ref: $COMMIT_SHA
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ COMMIT_SHA }}
+          ref: $COMMIT_SHA
       - name: Setup golang
         uses: actions/setup-go@v3
         with: 
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ COMMIT_SHA }}
+          ref: $COMMIT_SHA
       - name: Setup golang
         uses: actions/setup-go@v3
         with: 


### PR DESCRIPTION
Changes from ${{ name }} for use with environment variables.
This is the wrong syntax for use with environment variables. The correct syntax is $name.
The other syntax is for use with Github's contexts